### PR TITLE
Fixed bugs in import to clean mongo

### DIFF
--- a/lib/apt_nav_data.js
+++ b/lib/apt_nav_data.js
@@ -6,6 +6,10 @@ AptNavData = function(db)
   
   this.clearCollection = function(name,callback)
   {
+    if (typeof callback !== 'function') {
+      callback = function() {};
+    }
+
     var collection = this.db.collection(name);
     collection.remove({},callback);
   };
@@ -223,6 +227,10 @@ AptNavData = function(db)
   
   this.saveVariable = function(name,value, callback)
   {
+    if (typeof callback !== 'function') {
+      callback = function() {};
+    }
+
     var collection = this.db.collection('variables');
     collection.insert({name:name,value:value},callback);
   };
@@ -241,6 +249,10 @@ AptNavData = function(db)
   
   this.clearVariable = function(name,callback)
   {
+    if (typeof callback !== 'function') {
+      callback = function() {};
+    }
+
     var collection = this.db.collection('variables');
     collection.remove({name:name},callback);
   };


### PR DESCRIPTION
Hi! 
I wasn't able to import X-Plane apt data to clean mongo setup, so i've fixed this problem. 
It's similar fix to issue #21

On clean setup i've received errors like this on import:

Error: Cannot use a writeConcern without a provided callback
    at Collection.remove (/vagrant/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/collection.js:207:11)
    at EventEmitter.<anonymous> (/vagrant/node_modules/mongoskin/lib/mongoskin/utils.js:68:23)
    at EventEmitter.g (events.js:180:16)
    at EventEmitter.emit (events.js:98:17)
    at null.<anonymous> (/vagrant/node_modules/mongoskin/lib/mongoskin/collection.js:129:24)
    at Db.collection (/vagrant/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/db.js:488:44)
    at null.<anonymous> (/vagrant/node_modules/mongoskin/lib/mongoskin/collection.js:119:12)
    at SkinDb.open (/vagrant/node_modules/mongoskin/lib/mongoskin/db.js:79:19)
    at SkinCollection.open (/vagrant/node_modules/mongoskin/lib/mongoskin/collection.js:114:19)
    at obj.(anonymous function) [as remove](/vagrant/node_modules/mongoskin/lib/mongoskin/utils.js:64:10)

Error: Cannot use a writeConcern without a provided callback
    at Collection.remove (/vagrant/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/collection.js:207:11)
    at obj.(anonymous function) [as remove](/vagrant/node_modules/mongoskin/lib/mongoskin/utils.js:61:14)
    at clearVariable (/vagrant/lib/apt_nav_data.js:248:16)
    at exports.importAirports (/vagrant/routes/index.js:49:14)
    at callbacks (/vagrant/node_modules/express/lib/router/index.js:272:11)
    at param (/vagrant/node_modules/express/lib/router/index.js:246:11)
    at pass (/vagrant/node_modules/express/lib/router/index.js:253:5)
    at Router._dispatch (/vagrant/node_modules/express/lib/router/index.js:280:5)
    at Object.Router.middleware [as handle](/vagrant/node_modules/express/lib/router/index.js:45:10)
    at next (/vagrant/node_modules/express/node_modules/connect/lib/http.js:204:15)

Error: Cannot use a writeConcern without a provided callback
    at insertAll (/vagrant/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/collection.js:351:11)
    at Collection.insert (/vagrant/node_modules/mongoskin/node_modules/mongodb/lib/mongodb/collection.js:94:3)
    at obj.(anonymous function) [as insert](/vagrant/node_modules/mongoskin/lib/mongoskin/utils.js:61:14)
    at saveVariable (/vagrant/lib/apt_nav_data.js:231:16)
    at exports.importAirports (/vagrant/routes/index.js:50:14)
    at callbacks (/vagrant/node_modules/express/lib/router/index.js:272:11)
    at param (/vagrant/node_modules/express/lib/router/index.js:246:11)
    at pass (/vagrant/node_modules/express/lib/router/index.js:253:5)
    at Router._dispatch (/vagrant/node_modules/express/lib/router/index.js:280:5)
    at Object.Router.middleware [as handle](/vagrant/node_modules/express/lib/router/index.js:45:10)
